### PR TITLE
Decouple Vue front‑end from Flask back‑end & add CORS

### DIFF
--- a/backend/app/extensions.py
+++ b/backend/app/extensions.py
@@ -1,5 +1,6 @@
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
+from flask_cors import CORS
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -2,6 +2,7 @@ from .auth import auth
 from .dashboard import dashboard
 from .images import images
 
+
 def register_routes(app):
     app.register_blueprint(auth, url_prefix="/api/auth")
     app.register_blueprint(dashboard, url_prefix="/api/dashboard")

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -10,6 +10,7 @@ auth: Blueprint = Blueprint("auth", __name__, url_prefix="/api/auth")
 
 GOOGLE_TOKENINFO_URL: str = "https://oauth2.googleapis.com/tokeninfo"
 
+
 @auth.route("/google", methods=["POST"])
 def google_login() -> tuple[Response, int]:
     data: Optional[Dict[str, Any]] = request.get_json()

--- a/backend/app/routes/dashboard.py
+++ b/backend/app/routes/dashboard.py
@@ -6,8 +6,8 @@ from ..models import ActiveHike, Trail, Vote, Member, Signup, Vehicle, Waiver
 from ..decorators import admin_required
 from typing import List, Optional
 
-
 dashboard: Blueprint = Blueprint("dashboard", __name__)
+
 
 @dashboard.route('/upcoming', methods=['GET'])
 @admin_required

--- a/backend/app/routes/images.py
+++ b/backend/app/routes/images.py
@@ -2,9 +2,10 @@ from flask import send_from_directory, Blueprint
 
 images = Blueprint('images', __name__)
 
+
 @images.route('/uploads/<int:trail_id>.png')
 def trail_image(trail_id):
     return send_from_directory(
-        'static/uploads',       # relative to your Flask app root
+        'static/uploads',  # relative to your Flask app root
         f'{trail_id}.png'
     )

--- a/backend/config.py
+++ b/backend/config.py
@@ -19,6 +19,8 @@ class Config:
     JWT_ALGORITHM = os.getenv("JWT_ALGORITHM")
     JWT_EXP_HOURS = os.getenv("JWT_EXP_HOURS")
 
+    CORS_ORIGIN = os.getenv("CORS_ORIGIN")
+
     BASE_DIR = os.path.abspath(os.path.dirname(__file__))
     FRONTEND_DIST = os.path.join(BASE_DIR, '..', 'frontend', 'dist')
     STATIC_FOLDER = os.path.join(FRONTEND_DIST, 'assets')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv~=1.1.1
 pyjwt~=2.10.1
 requests~=2.32.4
 psycopg2-binary~=2.9.10
+flask_cors~=6.0.1

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -14,6 +14,7 @@ dist-ssr
 coverage
 *.local
 .env
+.env.development
 
 /cypress/videos/
 /cypress/screenshots/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1508,13 +1508,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -1771,9 +1771,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,4 +14,13 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
+  server: {
+    port: 5001,
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:5000',
+        changeOrigin: true
+      }
+    }
+  }
 })


### PR DESCRIPTION
### Description

This PR splits the monolith into a classic API + SPA setup. Vue is now built & served by Vite on port 5001, while Flask only exposes JSON routes on port 5000. CORS is enabled so the two can talk to each other securely in development and production.

### What Changed

## Back‑end

- Add flask_cors and register it (CORS(app, resources={r"/*": {"origins": CORS_ORIGIN}})).
- Delete legacy catch‑all route that served index.html.
- Expose CORS_ORIGIN in config.py.
- Minor linter/typing fixes in blueprints.

## Front‑end

-  vite.config.ts – dev server runs on 5001 and proxies /api to 5000.
- Bump axios → 1.11.0, form‑data → 4.0.4.
- Add .env.development to .gitignore.

## Deps

- flask_cors~=6.0.1 added to requirements.txt.

## Breaking / Required actions

- NEW ENV VAR: CORS_ORIGIN (e.g. http://localhost:5001 in dev).
- Re‑install Python deps & Node modules.
- Update any deployment scripts that previously relied on Flask serving the SPA.